### PR TITLE
update cloudflare challenge detection

### DIFF
--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -7,7 +7,6 @@ import {
   type ChapterDetails,
   type ChapterProviding,
   type CloudflareBypassRequestProviding,
-  CloudflareError,
   ContentRating,
   type Cookie,
   CookieStorageInterceptor,
@@ -21,7 +20,6 @@ import {
   type PagedResults,
   PaperbackInterceptor,
   type Request,
-  type Response,
   type SearchFilter,
   type SearchQuery,
   type SearchResultItem,
@@ -219,7 +217,9 @@ export abstract class MadaraGeneric
         : `${this.domain}/temp_dirpath/${mangaId}/`,
       method: "GET",
     });
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
     return this.parser.parseMangaDetails($, mangaId, this);
@@ -279,7 +279,9 @@ export abstract class MadaraGeneric
     }
 
     const [response, buffer] = await Application.scheduleRequest(requestConfig);
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -303,7 +305,9 @@ export abstract class MadaraGeneric
       url: url.toString(),
       method: "GET",
     });
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -373,7 +377,9 @@ export abstract class MadaraGeneric
       url: `${this.domain}/temp_dirpath/page/${page}/${param}`,
       method: "GET",
     });
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -392,7 +398,9 @@ export abstract class MadaraGeneric
       url: `${this.domain}/?s=&post_type=wp-manga`,
       method: "GET",
     });
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -424,7 +432,9 @@ export abstract class MadaraGeneric
 
     const [response, buffer] = await this.constructSearchRequest(page, query);
 
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -646,7 +656,9 @@ export abstract class MadaraGeneric
       method: "GET",
     });
 
-    await this.checkResponseError(response);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
+    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -655,27 +667,5 @@ export abstract class MadaraGeneric
     // Store parsed path else store the default (manga)
     Application.setState(path, `dirpath_${this.domain}`);
     return path;
-  }
-
-  async checkResponseError(response: Response): Promise<void> {
-    const status = response.status;
-    switch (status) {
-      case 403:
-      case 503:
-        throw new CloudflareError(
-          {
-            url: this.bypassPage ? this.bypassPage : this.domain,
-            method: "GET",
-            headers: {
-              referer: `${this.domain}/`,
-              origin: `${this.domain}/`,
-              "user-agent": await Application.getDefaultUserAgent(),
-            },
-          },
-          "Cloudflare detected!\nPlease do the Cloudflare bypass to continue!",
-        );
-      case 404:
-        throw new Error(`The requested page ${response.url} was not found!`);
-    }
   }
 }

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -211,15 +211,12 @@ export abstract class MadaraGeneric
   }
 
   async getMangaDetails(mangaId: string): Promise<SourceManga> {
-    const [response, buffer] = await Application.scheduleRequest({
+    const [_response, buffer] = await Application.scheduleRequest({
       url: getUsePostIds(this.usePostIds)
         ? `${this.domain}/?p=${mangaId}/`
         : `${this.domain}/temp_dirpath/${mangaId}/`,
       method: "GET",
     });
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
     return this.parser.parseMangaDetails($, mangaId, this);
@@ -278,10 +275,7 @@ export abstract class MadaraGeneric
         throw new Error("Invalid chapter endpoint!");
     }
 
-    const [response, buffer] = await Application.scheduleRequest(requestConfig);
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
+    const [_response, buffer] = await Application.scheduleRequest(requestConfig);
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -301,13 +295,10 @@ export abstract class MadaraGeneric
       url.setQueryItem("style", "list");
     }
 
-    const [response, buffer] = await Application.scheduleRequest({
+    const [_response, buffer] = await Application.scheduleRequest({
       url: url.toString(),
       method: "GET",
     });
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -373,13 +364,10 @@ export abstract class MadaraGeneric
         throw new Error("Invalid sectionId provided!");
     }
 
-    const [response, buffer] = await Application.scheduleRequest({
+    const [_response, buffer] = await Application.scheduleRequest({
       url: `${this.domain}/temp_dirpath/page/${page}/${param}`,
       method: "GET",
     });
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -394,13 +382,10 @@ export abstract class MadaraGeneric
   }
 
   async getSearchFilters(): Promise<SearchFilter[]> {
-    const [response, buffer] = await Application.scheduleRequest({
+    const [_response, buffer] = await Application.scheduleRequest({
       url: `${this.domain}/?s=&post_type=wp-manga`,
       method: "GET",
     });
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -430,11 +415,7 @@ export abstract class MadaraGeneric
   ): Promise<PagedResults<SearchResultItem>> {
     const page = metadata?.page ?? 1;
 
-    const [response, buffer] = await this.constructSearchRequest(page, query);
-
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
+    const [_response, buffer] = await this.constructSearchRequest(page, query);
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
@@ -651,14 +632,10 @@ export abstract class MadaraGeneric
       return getPath;
     }
 
-    const [response, buffer] = await Application.scheduleRequest({
+    const [_response, buffer] = await Application.scheduleRequest({
       url: `${this.domain}/?s=&post_type=wp-manga#directoryRequest`,
       method: "GET",
     });
-
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
-    }
 
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -91,6 +91,10 @@ export class MadaraInterceptor extends PaperbackInterceptor {
       );
     }
 
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}: ${request.url}`);
+    }
+
     return data;
   }
 }

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -1,7 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* Copyright © 2026 Inkdex */
 
-import { PaperbackInterceptor, type Request, type Response } from "@paperback/types";
+import {
+  CloudflareError,
+  PaperbackInterceptor,
+  type Request,
+  type Response,
+} from "@paperback/types";
 import { MadaraGeneric } from "./main";
 
 export class MadaraInterceptor extends PaperbackInterceptor {
@@ -70,6 +75,22 @@ export class MadaraInterceptor extends PaperbackInterceptor {
     response: Response,
     data: ArrayBuffer,
   ): Promise<ArrayBuffer> {
+    const cfMitigated = response.headers?.["cf-mitigated"];
+    if (cfMitigated === "challenge") {
+      throw new CloudflareError(
+        {
+          url: this.source.bypassPage ? this.source.bypassPage : this.source.domain,
+          method: "GET",
+          headers: {
+            referer: `${this.source.domain}/`,
+            origin: `${this.source.domain}/`,
+            "user-agent": await Application.getDefaultUserAgent(),
+          },
+        },
+        "Cloudflare detected!\nPlease do the Cloudflare bypass to continue!",
+      );
+    }
+
     return data;
   }
 }

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -87,7 +87,7 @@ export class MadaraInterceptor extends PaperbackInterceptor {
             "user-agent": await Application.getDefaultUserAgent(),
           },
         },
-        "Cloudflare detected!\nPlease do the Cloudflare bypass to continue!",
+        "Cloudflare detected, bypass it to continue!",
       );
     }
 


### PR DESCRIPTION
this also fixes the infinite cloudflare loop.

this can be moved to interceptor, changed to check 404 only, or removed all together, just let me know.

```
if (response.status !== 200) {
      throw new Error(`Request failed with status ${response.status}: ${response.url}`);
    }
```