### PR TITLE
Fix Yaoiscans parsing issues

### DIFF
--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -480,12 +480,9 @@ export abstract class MadaraGeneric
     });
   }
 
+  // convert smart quotes (iOS uses them by default)
   sanitizeQuery(query: string): string {
-    return query
-      .replace(/'[^ ]*/g, "") // Remove apostrophes and the following characters up to a space
-      .replace(/\.+/g, "") // Remove all periods
-      .replace(/["']/g, "") // Remove quotes
-      .trim();
+    return query.replace(/[‘’]/g, "'").replace(/[“”]/g, '"');
   }
 
   async getPostAndSlug(mangaId: string) {

--- a/src/generic/utils.ts
+++ b/src/generic/utils.ts
@@ -3,7 +3,7 @@
 
 import CryptoJS from "crypto-js";
 
-const BASE_VERSION = "1.0.0-alpha.5";
+const BASE_VERSION = "1.0.0-alpha.6";
 
 export function getVersion(
   options?:


### PR DESCRIPTION
iOS by default uses smart quotes, which can be very annoying for searching.

I've removed that, and also found that the sanitizeQuery was unnecessary since URI encoding works out of the box on node.

<img width="910" height="1970" alt="image" src="https://github.com/user-attachments/assets/c25e136b-59c5-4e5e-8447-6c8cf45d1c03" />

This fixes user issue: 
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/ed94518f-318b-40c8-95f2-aba6a60e8b84" />

Future PR will address Toonily search issues.
