### PR TITLE
fix: Update directoryPath parsing to be more accurate, update HiperDex search selectors and domain, set volumes to 0 to remove TBA volumes 

### DIFF
--- a/src/HiperDex/main.ts
+++ b/src/HiperDex/main.ts
@@ -4,7 +4,7 @@
 import { MadaraGeneric } from "../generic/main";
 import pbconfig from "./pbconfig";
 
-const DOMAIN: string = "https://hiperdex.tv";
+const DOMAIN: string = "https://hiperdex.com";
 
 class HiperDexExtension extends MadaraGeneric {
   constructor() {
@@ -14,6 +14,7 @@ class HiperDexExtension extends MadaraGeneric {
       contentRating: pbconfig.contentRating,
       language: pbconfig.language,
       usePostIds: true,
+      searchMangaSelector: "div.page-item-detail",
     });
   }
 }

--- a/src/generic/parsers.ts
+++ b/src/generic/parsers.ts
@@ -344,14 +344,6 @@ export class MadaraParser {
   }
 
   parseDirectoryPath($: CheerioAPI, source: MadaraGeneric): string {
-    // Parse path from meta property
-    const url = $('meta[property="og:url"]').attr("content") ?? "";
-    const fullPath = url.replace(source.domain, "");
-    const pathSegment = (fullPath.split("/")[1] ?? "").trim();
-    if (pathSegment) {
-      return pathSegment;
-    }
-
     // Parse path from first search result
     const searchResult = $(source.searchMangaSelector).first();
     const searchResultPath: string =
@@ -361,6 +353,14 @@ export class MadaraParser {
       return searchResultPath;
     }
 
+    // Fallback: Parse path from meta property
+    const url = $('meta[property="og:url"]').attr("content") ?? "";
+    const fullPath = url.replace(source.domain, "");
+    const pathSegment = (fullPath.split("/")[1] ?? "").trim();
+    if (pathSegment) {
+      return pathSegment;
+    }
+    
     return "manga";
   }
 

--- a/src/generic/parsers.ts
+++ b/src/generic/parsers.ts
@@ -173,6 +173,7 @@ export class MadaraParser {
         title: chapName ? Application.decodeHTMLEntities(chapName) : "",
         publishDate: mangaTime,
         sortingIndex: sortingIndex,
+        volume: 0
       });
     }
 

--- a/src/generic/parsers.ts
+++ b/src/generic/parsers.ts
@@ -173,7 +173,7 @@ export class MadaraParser {
         title: chapName ? Application.decodeHTMLEntities(chapName) : "",
         publishDate: mangaTime,
         sortingIndex: sortingIndex,
-        volume: 0
+        volume: 0,
       });
     }
 
@@ -360,7 +360,7 @@ export class MadaraParser {
     if (pathSegment) {
       return pathSegment;
     }
-    
+
     return "manga";
   }
 

--- a/src/generic/utils.ts
+++ b/src/generic/utils.ts
@@ -3,7 +3,7 @@
 
 import CryptoJS from "crypto-js";
 
-const BASE_VERSION = "1.0.0-alpha.6";
+const BASE_VERSION = "1.0.0-alpha.7";
 
 export function getVersion(
   options?:


### PR DESCRIPTION
This should resolve Toonily's parsing issues, as directoryPath now properly retrieves `serie` instead of `search`, which was happening previously.