### PR TITLE
fix(generic): pagination

### DIFF
--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -417,6 +417,10 @@ export abstract class MadaraGeneric
 
     const [_response, buffer] = await this.constructSearchRequest(page, query);
 
+    if (_response.status === 404) {
+      return { items: [], metadata: undefined }; // Madara doesn't support last page checking, will return 404 on website!
+    }
+
     const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
 
     const results = await this.parser.parseSearchResults($, this);
@@ -443,7 +447,7 @@ export abstract class MadaraGeneric
 
     return {
       items: items,
-      metadata: { page: page + 1 }, // Madara doesn't support last page checking, will return 404 on website!
+      metadata: items.length > 0 ? { page: page + 1 } : undefined,
     };
   }
 

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -92,6 +92,9 @@ export class MadaraInterceptor extends PaperbackInterceptor {
     }
 
     if (response.status !== 200) {
+      if (response.status === 404 && request.url.includes(this.source.searchPagePathName)) {
+        return data;
+      }
       throw new Error(`Request failed with status ${response.status}: ${request.url}`);
     }
 

--- a/src/generic/utils.ts
+++ b/src/generic/utils.ts
@@ -3,7 +3,7 @@
 
 import CryptoJS from "crypto-js";
 
-const BASE_VERSION = "1.0.0-alpha.7";
+const BASE_VERSION = "1.0.0-alpha.8";
 
 export function getVersion(
   options?:


### PR DESCRIPTION
- allow 404 through the response interceptor when the request is a search page request
- return undefined metadata when items is empty to stop pagination cleanly