### PR TITLE
fix(ManhwaRaw): set default directoryPath for cloudflare

### DIFF
--- a/src/ManhwaRaw/main.ts
+++ b/src/ManhwaRaw/main.ts
@@ -14,6 +14,7 @@ class ManhwaRawExtension extends MadaraGeneric {
       contentRating: pbconfig.contentRating,
       language: pbconfig.language,
       usePostIds: true,
+      directoryPath: "manga",
     });
   }
 }

--- a/src/ManhwaRaw/pbconfig.ts
+++ b/src/ManhwaRaw/pbconfig.ts
@@ -3,7 +3,7 @@
 
 import { ContentRating } from "@paperback/types";
 
-import { basePbConfig } from "../generic/config";
+import { basePbConfig, customVersion } from "../generic/config";
 
 let pbConfig = basePbConfig;
 
@@ -11,5 +11,6 @@ pbConfig.name = "ManhwaRaw";
 pbConfig.description = "Extension that pulls content from manhwa-raw.com.";
 pbConfig.language = "ko";
 pbConfig.contentRating = ContentRating.ADULT;
+pbConfig.version = customVersion({ increasePrerelease: 1 });
 
 export default pbConfig;


### PR DESCRIPTION
- seems like when its determined automatically it hits the site root rather than one of the used endpoints, but only on mobile. not going to dig into why, just going to specify the path to use

# Summary

<!-- What changed and why. 1-3 sentences. -->

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
