### PR TITLE
fix(ArthurScan): support Madara X theme

### DIFF
--- a/src/ArthurScan/main.ts
+++ b/src/ArthurScan/main.ts
@@ -2,6 +2,7 @@
 /* Copyright © 2026 Inkdex */
 
 import { MadaraGeneric } from "../generic/main";
+import { ArthurScanParser } from "./parsers";
 import pbconfig from "./pbconfig";
 
 const DOMAIN: string = "https://arthurscan.xyz";
@@ -15,6 +16,8 @@ class ArthurScanExtension extends MadaraGeneric {
       language: pbconfig.language,
       usePostIds: true,
       chapterEndpoint: 1,
+      searchMangaSelector: "div.manga__item",
+      parser: new ArthurScanParser(),
     });
   }
 }

--- a/src/ArthurScan/parsers.ts
+++ b/src/ArthurScan/parsers.ts
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 Inkdex */
+
+import {
+  type Chapter,
+  type DiscoverSection,
+  type DiscoverSectionItem,
+  DiscoverSectionType,
+  type SourceManga,
+} from "@paperback/types";
+import type { CheerioAPI } from "cheerio";
+
+import { getUsePostIds } from "../generic/forms";
+import { MadaraGeneric } from "../generic/main";
+import { MadaraParser } from "../generic/parsers";
+
+// Overrides for ArthurScan's "Madara X" theme: `div.manga__item` search and
+// discover markup, and Portuguese chapter dates.
+export class ArthurScanParser extends MadaraParser {
+  override async parseSearchResults($: CheerioAPI, source: MadaraGeneric) {
+    const results = [];
+
+    for (const obj of $(source.searchMangaSelector).toArray()) {
+      const titleAnchor = $("div.post-title a", obj).first();
+
+      const slug: string =
+        (titleAnchor.attr("href") ?? $("a", obj).attr("href") ?? "")
+          .replace(/\/$/, "")
+          .split("/")
+          .pop() ?? "";
+
+      if (!slug) {
+        throw new Error(`Unable to parse slug  (${slug})!`);
+      }
+
+      const title: string = titleAnchor.text().trim();
+      const image: string = encodeURI(await this.getImageSrc($("img", obj), source));
+
+      results.push({
+        slug: slug,
+        image: image,
+        title: Application.decodeHTMLEntities(title),
+        subtitle: "",
+      });
+    }
+
+    return results;
+  }
+
+  override async parseDiscoverSections(
+    $: CheerioAPI,
+    section: DiscoverSection,
+    source: MadaraGeneric,
+  ): Promise<DiscoverSectionItem[]> {
+    const items: DiscoverSectionItem[] = [];
+
+    for (const obj of $("div.manga__item").toArray()) {
+      const titleAnchor = $("div.post-title a", obj).first();
+
+      const slug: string =
+        (titleAnchor.attr("href") ?? "").replace(/\/$/, "").split("/").pop() ?? "";
+      const title: string = titleAnchor.text().trim();
+
+      if (!slug || !title) {
+        continue;
+      }
+
+      const image: string = encodeURI(
+        (await this.getImageSrc($("img", obj).first(), source)) ?? "",
+      );
+      const subtitle: string = $("div.list-chapter span.chapter", obj).first().text().trim();
+
+      const mangaId: string = getUsePostIds(source.usePostIds)
+        ? (await source.getPostAndSlug(slug)).postId
+        : slug;
+
+      const base = {
+        mangaId: mangaId,
+        imageUrl: image,
+        title: Application.decodeHTMLEntities(title),
+      };
+
+      switch (section.type) {
+        case DiscoverSectionType.featured:
+          items.push({
+            ...base,
+            supertitle: Application.decodeHTMLEntities(subtitle),
+            type: "featuredCarouselItem",
+          });
+          break;
+
+        case DiscoverSectionType.prominentCarousel:
+          items.push({
+            ...base,
+            subtitle: Application.decodeHTMLEntities(subtitle),
+            type: "prominentCarouselItem",
+          });
+          break;
+
+        default:
+          items.push({
+            ...base,
+            subtitle: Application.decodeHTMLEntities(subtitle),
+            type: "simpleCarouselItem",
+          });
+          break;
+      }
+    }
+
+    return items;
+  }
+
+  override parseChapterList(
+    $: CheerioAPI,
+    sourceManga: SourceManga,
+    source: MadaraGeneric,
+  ): Chapter[] {
+    const chapters: Chapter[] = [];
+    const nodeArray = $("li.wp-manga-chapter  ").toArray();
+    let nodesProcessed = 0;
+
+    for (const obj of nodeArray) {
+      const sortingIndex = nodeArray.length - nodesProcessed++;
+      const id = this.idCleaner($("a", obj).first().attr("href") ?? "");
+
+      const chapName = $("a", obj).first().text().trim() ?? "";
+      const chapNumRegex = id.match(
+        /(?:chapter|ch.*?)(\d+\.?\d?(?:[-_]\d+)?)|(\d+\.?\d?(?:[-_]\d+)?)$/,
+      );
+      let chapNum: string | number =
+        chapNumRegex && chapNumRegex[1]
+          ? chapNumRegex[1].replace(/[-_]/gm, ".")
+          : (chapNumRegex?.[2] ?? "0");
+      chapNum = parseFloat(chapNum) ?? 0;
+
+      const titleDate = $("span.chapter-release-date a", obj).attr("title");
+      const dateText =
+        titleDate && titleDate.trim()
+          ? titleDate.trim()
+          : $("span.chapter-release-date", obj).text().trim();
+      let mangaTime = this.parseDate(dateText);
+      if (!mangaTime.getTime()) mangaTime = new Date();
+
+      if (!id || typeof id === "undefined" || id === "#") {
+        console.log(
+          `Could not parse out ID when getting chapters for mangaId:${sourceManga.mangaId} parsedId: ${id}`,
+        );
+        continue;
+      }
+
+      chapters.push({
+        sourceManga: sourceManga,
+        chapterId: id,
+        langCode: source.language,
+        chapNum: chapNum,
+        title: chapName ? Application.decodeHTMLEntities(chapName) : "",
+        publishDate: mangaTime,
+        sortingIndex: sortingIndex,
+        volume: 0,
+      });
+    }
+
+    return chapters;
+  }
+
+  override parseDate = (date: string): Date => {
+    const original = date.trim();
+    const lower = original.toLowerCase();
+
+    if (lower.includes("agora") || lower.includes("há poucos segundos")) {
+      return new Date();
+    }
+
+    const timeUnits: Record<string, number> = {
+      ano: 31556952000,
+      anos: 31556952000,
+      mês: 2592000000,
+      mes: 2592000000,
+      meses: 2592000000,
+      semana: 604800000,
+      semanas: 604800000,
+      dia: 86400000,
+      dias: 86400000,
+      hora: 3600000,
+      horas: 3600000,
+      minuto: 60000,
+      minutos: 60000,
+      segundo: 1000,
+      segundos: 1000,
+    };
+
+    const relativeMatch = lower.match(
+      /(\d+)\s*(anos?|meses|m[êe]s|semanas?|dias?|horas?|minutos?|segundos?)/,
+    );
+    if (relativeMatch) {
+      const [, numStr, unit] = relativeMatch;
+      return new Date(Date.now() - Number(numStr) * timeUnits[unit]);
+    }
+
+    const months: Record<string, string> = {
+      janeiro: "January",
+      fevereiro: "February",
+      março: "March",
+      marco: "March",
+      abril: "April",
+      maio: "May",
+      junho: "June",
+      julho: "July",
+      agosto: "August",
+      setembro: "September",
+      outubro: "October",
+      novembro: "November",
+      dezembro: "December",
+    };
+
+    let normalized = original;
+    for (const [pt, en] of Object.entries(months)) {
+      normalized = normalized.replace(new RegExp(pt, "gi"), en);
+    }
+
+    const parsed = new Date(normalized);
+    return isNaN(parsed.getTime()) ? new Date() : parsed;
+  };
+}

--- a/src/ArthurScan/pbconfig.ts
+++ b/src/ArthurScan/pbconfig.ts
@@ -9,7 +9,7 @@ let pbConfig = basePbConfig;
 
 pbConfig.name = "ArthurScan";
 pbConfig.description = "Extension that pulls content from arthurscan.xyz.";
-pbConfig.version = customVersion({ increasePrerelease: 1 });
+pbConfig.version = customVersion({ increasePrerelease: 2 });
 pbConfig.language = "pt";
 pbConfig.contentRating = ContentRating.MATURE;
 


### PR DESCRIPTION
# Summary

ArthurScan migrated to the "Madara X" theme, which broke search, discover, and chapter dates. Search/discover pages now use `div.manga__item` markup (title as anchor text, no `data-post-id`) instead of the generic `div.c-tabs-item__content` / `div.page-item-detail`, and chapter release dates are plain Portuguese text inside `span.chapter-release-date`. Added an `ArthurScanParser` overriding the affected parsing and pointed `searchMangaSelector` at the new layout.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
