### PR TITLE
feat(UToon): support the custom UTOON-ZAX theme

### DIFF
--- a/src/UToon/main.ts
+++ b/src/UToon/main.ts
@@ -1,11 +1,24 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* Copyright © 2026 Inkdex */
 
+/* Adapted from Nicartjay's reference source:
+ * https://github.com/Nicartjay/PaperbackExt/blob/0.9/stable/src/Utoon/main.ts */
+
+import {
+  type DiscoverSection,
+  type DiscoverSectionItem,
+  type PagedResults,
+} from "@paperback/types";
+import * as cheerio from "cheerio";
+
 import { MadaraGeneric } from "../generic/main";
+import { UToonParser } from "./parsers";
 import pbconfig from "./pbconfig";
 
 const DOMAIN: string = "https://utoon.net";
 
+// utoon.net runs the custom "UTOON-ZAX" theme: the standard Madara request flow is intact,
+// so only the markup parsing (UToonParser) and the discover `?orderby=` sort params differ.
 class UToonExtension extends MadaraGeneric {
   constructor() {
     super({
@@ -13,8 +26,51 @@ class UToonExtension extends MadaraGeneric {
       name: pbconfig.name,
       contentRating: pbconfig.contentRating,
       language: pbconfig.language,
-      usePostIds: true,
+      usePostIds: false,
+      searchMangaSelector: "a.acard",
+      chapterEndpoint: 3,
+      directoryPath: "manga",
+      parser: new UToonParser(),
     });
+  }
+
+  override async getDiscoverSectionItems(
+    section: DiscoverSection,
+    metadata: { page?: number } | undefined,
+  ): Promise<PagedResults<DiscoverSectionItem>> {
+    let param = "";
+    const page = metadata?.page ?? 1;
+
+    // The theme sorts via `?orderby=` (not Madara's `m_orderby`); trending reuses popular.
+    switch (section.id) {
+      case "new_series":
+        param = "?orderby=new";
+        break;
+      case "recently_updated":
+        param = ""; // No param = the default "recently updated" listing.
+        break;
+      case "currently_trending":
+      case "most_popular":
+        param = "?orderby=popular";
+        break;
+
+      default:
+        throw new Error("Invalid sectionId provided!");
+    }
+
+    const [_response, buffer] = await Application.scheduleRequest({
+      url: `${this.domain}/temp_dirpath/page/${page}/${param}`,
+      method: "GET",
+    });
+
+    const $ = cheerio.load(Application.arrayBufferToUTF8String(buffer));
+
+    const items = await this.parser.parseDiscoverSections($, section, this);
+
+    return {
+      items,
+      metadata: items.length > 0 ? { page: page + 1 } : undefined,
+    };
   }
 }
 

--- a/src/UToon/models.ts
+++ b/src/UToon/models.ts
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 Inkdex */
+
+export const BOOK_TYPES = ["MangaToon", "Manwha", "Manhwa", "Manhua", "Manga"] as const;
+export type BookType = (typeof BOOK_TYPES)[number];
+
+export interface ParsedSynopsis {
+  bookTypes: BookType[];
+  alternativeNames: string[];
+  synopsis: string;
+}

--- a/src/UToon/parsers.ts
+++ b/src/UToon/parsers.ts
@@ -1,0 +1,379 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright © 2026 Inkdex */
+
+import {
+  type Chapter,
+  type DiscoverSection,
+  type DiscoverSectionItem,
+  DiscoverSectionType,
+  type SourceManga,
+  type Tag,
+  type TagSection,
+} from "@paperback/types";
+import type { CheerioAPI } from "cheerio";
+
+import { MadaraGeneric } from "../generic/main";
+import { MadaraParser } from "../generic/parsers";
+import { BOOK_TYPES, type BookType, type ParsedSynopsis } from "./models";
+
+export class UToonParser extends MadaraParser {
+  override async parseSearchResults($: CheerioAPI, source: MadaraGeneric) {
+    const results: {
+      slug: string;
+      image: string;
+      title: string;
+      subtitle: string;
+    }[] = [];
+    const seen = new Set<string>();
+
+    for (const obj of $("a.acard").toArray()) {
+      const href = $(obj).attr("href") ?? "";
+      const slug = href.replace(/\/$/, "").split("/").pop() ?? "";
+      if (!slug || seen.has(slug)) {
+        continue;
+      }
+
+      const img = $("img", obj).first();
+      const title = $("div.ac-t", obj).first().text().trim() || (img.attr("alt") ?? "").trim();
+      if (!title) {
+        continue;
+      }
+
+      const subtitle = $("div.ac-ch", obj).first().text().trim();
+
+      seen.add(slug);
+      results.push({
+        slug,
+        image: encodeURI(await this.getImageSrc(img, source)),
+        title: Application.decodeHTMLEntities(title),
+        subtitle: subtitle ? Application.decodeHTMLEntities(subtitle) : "",
+      });
+    }
+
+    return results;
+  }
+
+  override async parseDiscoverSections(
+    $: CheerioAPI,
+    section: DiscoverSection,
+    source: MadaraGeneric,
+  ): Promise<DiscoverSectionItem[]> {
+    const items: DiscoverSectionItem[] = [];
+
+    for (const card of await this.parseSearchResults($, source)) {
+      const base = {
+        mangaId: card.slug,
+        imageUrl: card.image,
+        title: card.title,
+      };
+
+      switch (section.type) {
+        case DiscoverSectionType.featured:
+          items.push({
+            ...base,
+            supertitle: card.subtitle,
+            type: "featuredCarouselItem",
+          });
+          break;
+        case DiscoverSectionType.prominentCarousel:
+          items.push({
+            ...base,
+            subtitle: card.subtitle,
+            type: "prominentCarouselItem",
+          });
+          break;
+        default:
+          items.push({
+            ...base,
+            subtitle: card.subtitle,
+            type: "simpleCarouselItem",
+          });
+          break;
+      }
+    }
+
+    return items;
+  }
+
+  override async parseMangaDetails(
+    $: CheerioAPI,
+    mangaId: string,
+    source: MadaraGeneric,
+  ): Promise<SourceManga> {
+    const primaryTitle = Application.decodeHTMLEntities($("h1.htitle").first().text().trim());
+
+    const secondaryTitles: string[] = [];
+    $("div.halt-list span.halt-tag").each((_, el) => {
+      const alt = Application.decodeHTMLEntities($(el).text().trim());
+      if (alt && alt !== primaryTitle && !secondaryTitles.includes(alt)) {
+        secondaryTitles.push(alt);
+      }
+    });
+
+    // Poster, falling back to the hero background, then og:image.
+    let thumbnailUrl = await this.getImageSrc($("div.poster img").first(), source);
+    if (!thumbnailUrl) {
+      const heroStyle = $("div.hero__bg").first().attr("style") ?? "";
+      const bg = heroStyle.match(/url\(\s*['"]?([^'")]+)['"]?\s*\)/i);
+      if (bg && bg[1]) {
+        thumbnailUrl = bg[1].trim();
+      }
+    }
+    if (!thumbnailUrl) {
+      thumbnailUrl = ($('meta[property="og:image"]').first().attr("content") ?? "").trim();
+    }
+    thumbnailUrl = encodeURI(thumbnailUrl);
+
+    const parsed = parseSynopsis(
+      Application.decodeHTMLEntities($("div.syn, #syn").first().text().trim()),
+    );
+    const synopsis = parsed.synopsis;
+    const allSecondaryTitles = mergeAlternativeNames(
+      secondaryTitles,
+      parsed.alternativeNames,
+    ).filter((title) => title.toLowerCase() !== primaryTitle.toLowerCase());
+
+    const info: Record<string, string> = {};
+    $("div.sinfo-grid div.sir").each((_, el) => {
+      const label = $(el).find("span.l").text().trim().toLowerCase();
+      const value = $(el).find("span.v").text().trim();
+      if (label) {
+        info[label] = value;
+      }
+    });
+
+    const author =
+      info["author"] && !/^\d+$/.test(info["author"])
+        ? Application.decodeHTMLEntities(info["author"])
+        : "";
+
+    const genreTags: Tag[] = [];
+    const seenGenre = new Set<string>();
+    const pushGenre = (name: string): void => {
+      const title = name.trim();
+      if (!title) {
+        return;
+      }
+      const id = title.toLowerCase().replace(/\s+/g, "-");
+      if (seenGenre.has(id)) {
+        return;
+      }
+      seenGenre.add(id);
+      genreTags.push({ id, title });
+    };
+    for (const el of $("div.genres a.genre").toArray()) {
+      pushGenre($(el).text());
+    }
+    if (info["type"]) {
+      pushGenre(info["type"]);
+    }
+    for (const bookType of parsed.bookTypes) {
+      pushGenre(bookType);
+    }
+    const tagGroups: TagSection[] = [{ id: "genres", title: "Genres", tags: genreTags }];
+
+    // Score is "out of 5"; Paperback expects a 0–1 fraction, so divide by 5.
+    let rating = 0;
+    const ratingValue = parseFloat($("div.rc-score .rc-num, #rAvg").first().text().trim());
+    if (!isNaN(ratingValue)) {
+      rating = Math.max(0, Math.min(1, ratingValue / 5));
+    }
+
+    return {
+      mangaId,
+      mangaInfo: {
+        primaryTitle,
+        secondaryTitles: allSecondaryTitles,
+        thumbnailUrl,
+        author,
+        synopsis,
+        rating,
+        contentRating: source.defaultContentRating,
+        status: this.parseStatus(info["status"] ?? ""),
+        tagGroups,
+        shareUrl: `${source.domain}/${await source.getDirectoryPath()}/${mangaId}`,
+      },
+    };
+  }
+
+  // Full list lives in a `var CH=[...]` array; the DOM has only the first page.
+  override parseChapterList(
+    $: CheerioAPI,
+    sourceManga: SourceManga,
+    source: MadaraGeneric,
+  ): Chapter[] {
+    const embedded = this.parseEmbeddedChapters($.root().html() ?? "", sourceManga, source);
+    if (embedded !== null) {
+      return embedded;
+    }
+    return super.parseChapterList($, sourceManga, source);
+  }
+
+  private parseEmbeddedChapters(
+    html: string,
+    sourceManga: SourceManga,
+    source: MadaraGeneric,
+  ): Chapter[] | null {
+    const literal = extractArrayLiteral(html, /var\s+CH\s*=\s*/);
+    if (literal === null) {
+      return null;
+    }
+
+    let raws: {
+      label?: string;
+      url?: string;
+      ago?: string;
+      locked?: boolean;
+      num?: number;
+    }[];
+    try {
+      raws = JSON.parse(literal);
+    } catch {
+      return null;
+    }
+
+    const chapters: Chapter[] = [];
+    for (let i = 0; i < raws.length; i++) {
+      const raw = raws[i];
+      if (!raw || !raw.url || raw.locked) {
+        continue;
+      }
+
+      let chapterId: string;
+      try {
+        chapterId = this.idCleaner(raw.url); // throws on a url with no path tail; skip it
+      } catch {
+        continue;
+      }
+
+      const title = Application.decodeHTMLEntities((raw.label ?? "").trim());
+
+      let chapNum = typeof raw.num === "number" ? raw.num : 0;
+      if (!chapNum) {
+        const numMatch = title.match(/chapter[.\s-]*(\d+(?:\.\d+)?)/i);
+        if (numMatch && numMatch[1]) {
+          chapNum = parseFloat(numMatch[1]);
+        }
+      }
+
+      let publishDate = this.parseDate(raw.ago ?? "");
+      if (!publishDate.getTime()) {
+        publishDate = new Date();
+      }
+
+      chapters.push({
+        sourceManga,
+        chapterId,
+        langCode: source.language,
+        chapNum,
+        title,
+        publishDate,
+        sortingIndex: raws.length - i,
+        volume: 0,
+      });
+    }
+
+    return chapters;
+  }
+
+  private parseStatus(raw: string): string {
+    switch (raw.trim().toUpperCase()) {
+      case "COMPLETED":
+        return "Completed";
+      case "HIATUS":
+        return "Hiatus";
+      case "CANCELLED":
+      case "CANCELED":
+      case "DROPPED":
+        return "Cancelled";
+      default:
+        return "Ongoing";
+    }
+  }
+}
+
+// Balanced-bracket scan for the `[...]` array literal after `assignment`, ignoring brackets inside
+// JSON strings. Returns null if no well-formed array is found.
+function extractArrayLiteral(html: string, assignment: RegExp): string | null {
+  const match = html.match(assignment);
+  if (match?.index === undefined) {
+    return null;
+  }
+
+  const start = html.indexOf("[", match.index + match[0].length);
+  if (start === -1) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < html.length; i++) {
+    const c = html[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') inString = true;
+    else if (c === "[") depth++;
+    else if (c === "]" && --depth === 0) return html.slice(start, i + 1);
+  }
+  return null;
+}
+
+// Splits an optional "Read <BookType>... <AltName>..." header from the body.
+export function parseSynopsis(synopsisText: string): ParsedSynopsis {
+  const full = synopsisText.trim();
+  const lines = full.split("\n");
+  const headerIndex = lines.findIndex((line) => line.trim() !== "");
+  const readMatch = lines[headerIndex]?.trim().match(/^Read\s+(.+)$/);
+
+  // Body starts after a blank separator, else right after the header line. If the header IS the
+  // whole text (no body), don't parse it — that would swallow the description into alt names.
+  const separatorIndex = lines.findIndex((line, i) => i > headerIndex && line.trim() === "");
+  const bodyIndex = separatorIndex === -1 ? headerIndex + 1 : separatorIndex + 1;
+  if (!readMatch || bodyIndex >= lines.length) {
+    return { bookTypes: [], alternativeNames: [], synopsis: full };
+  }
+
+  const bookTypes: BookType[] = [];
+  const alternativeNames: string[] = [];
+
+  for (const part of readMatch[1].split(/\s*\/\s*/)) {
+    const token = part.trim();
+    if (!token) continue;
+
+    // BOOK_TYPES is ordered so MangaToon matches before Manga.
+    const bookType = BOOK_TYPES.find((bt) => token === bt || token.startsWith(`${bt} `));
+    if (bookType) {
+      if (!bookTypes.includes(bookType)) bookTypes.push(bookType);
+      // Book type and the first alt name can share one token, e.g. "Manhwa The Great Mage".
+      const altName = token.slice(bookType.length).trim();
+      if (altName) alternativeNames.push(altName);
+    } else {
+      alternativeNames.push(token);
+    }
+  }
+
+  const synopsis = lines.slice(bodyIndex).join("\n").trim();
+
+  return { bookTypes, alternativeNames, synopsis };
+}
+
+// Appends `parsedNames` to `existingNames`, deduping case- and whitespace-insensitively.
+export function mergeAlternativeNames(existingNames: string[], parsedNames: string[]): string[] {
+  const normalize = (title: string) => title.trim().toLowerCase().replace(/\s+/g, " ");
+  const seen = new Set(existingNames.map(normalize));
+  const merged = [...existingNames];
+
+  for (const name of parsedNames) {
+    if (!seen.has(normalize(name))) {
+      seen.add(normalize(name));
+      merged.push(name); // keep original casing
+    }
+  }
+
+  return merged;
+}

--- a/src/UToon/pbconfig.ts
+++ b/src/UToon/pbconfig.ts
@@ -3,12 +3,13 @@
 
 import { ContentRating } from "@paperback/types";
 
-import { basePbConfig } from "../generic/config";
+import { basePbConfig, customVersion } from "../generic/config";
 
 let pbConfig = basePbConfig;
 
 pbConfig.name = "UToon";
 pbConfig.description = "Extension that pulls content from utoon.net.";
 pbConfig.contentRating = ContentRating.ADULT;
+pbConfig.version = customVersion({ increasePrerelease: 1 });
 
 export default pbConfig;

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -504,19 +504,15 @@ export abstract class MadaraGeneric
     let slug: string = "";
 
     if (!isPostId) {
-      if (getUsePostIds()) {
-        // If provided mangaId is NOT a postId, but a slug AND we care about having the postId
-        const slugInput = mangaId.toString();
+      // mangaId is already the slug
+      slug = mangaId.toString();
 
-        // Fetch postId for slug
-        postId = Application.getState(slugInput) as number;
-
-        // If unable to fetch postId, turn slug into postId
+      // Only resolve the postId when this source actually uses post IDs
+      if (getUsePostIds(this.usePostIds)) {
+        postId = Application.getState(slug) as number;
         if (!postId) {
-          postId = await this.convertSlugToPostId(slugInput);
+          postId = await this.convertSlugToPostId(slug);
         }
-
-        slug = slugInput;
       }
     } else {
       // If mangaId IS a postId
@@ -534,7 +530,7 @@ export abstract class MadaraGeneric
     }
 
     // We only need to store these if we actually care about them
-    if (getUsePostIds()) {
+    if (getUsePostIds(this.usePostIds)) {
       Application.setState(postId.toString(), slug);
       Application.setState(slug, postId.toString());
     }


### PR DESCRIPTION
# Summary

Adds support for the custom **UTOON-ZAX** theme used by utoon.net. Since this theme diverges from stock Madara markup, the extension overrides search, discover, manga details, and the chapter list, while reusing the generic base for `getChapterDetails` (the reader still serves classic Madara markup).



## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [ ] This PR contains no AI-assisted changes.
- [x] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
