### PR TITLE
Fix LilyManga Search Selector, Add ReCaptcha bypass

### DIFF
--- a/src/LilyManga/main.ts
+++ b/src/LilyManga/main.ts
@@ -15,6 +15,7 @@ class LilyMangaExtension extends MadaraGeneric {
       language: pbconfig.language,
       usePostIds: true,
       chapterEndpoint: 1,
+      searchMangaSelector: "div.page-item-detail",
     });
   }
 }

--- a/src/generic/config.ts
+++ b/src/generic/config.ts
@@ -3,7 +3,7 @@
 
 import { ContentRating, SourceIntents, type ExtensionInfo } from "@paperback/types";
 
-const BASE_VERSION = "1.0.0-alpha.12";
+const BASE_VERSION = "1.0.0-alpha.13";
 
 export const basePbConfig = {
   name: "",

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -3,30 +3,24 @@
 
 import {
   BasicRateLimiter,
+  ContentRating,
+  CookieStorageInterceptor,
+  DiscoverSectionType,
+  Form,
+  PaperbackInterceptor,
+  URL,
   type Chapter,
   type ChapterDetails,
-  type ChapterProviding,
-  type CloudflareBypassRequestProviding,
-  ContentRating,
   type Cookie,
-  CookieStorageInterceptor,
   type DiscoverSection,
   type DiscoverSectionItem,
-  type DiscoverSectionProviding,
-  DiscoverSectionType,
-  type Extension,
-  Form,
-  type MangaProviding,
+  type ExtensionImpl,
   type PagedResults,
-  PaperbackInterceptor,
   type Request,
   type SearchQuery,
   type SearchResultItem,
-  type SearchResultsProviding,
-  type SettingsFormProviding,
   type SourceManga,
   type TagSection,
-  URL,
 } from "@paperback/types";
 import {
   SearchFilterForm,
@@ -35,6 +29,7 @@ import {
 } from "@paperback/types/lib/compat/0.8";
 import * as cheerio from "cheerio";
 
+import type { basePbConfig } from "./config";
 import { getUsePostIds, MadaraSettings } from "./forms";
 import { MadaraInterceptor } from "./network";
 import { MadaraParser } from "./parsers";
@@ -65,16 +60,7 @@ type Metadata = {
   completed?: boolean;
 };
 
-export abstract class MadaraGeneric
-  implements
-    Extension,
-    SearchResultsProviding,
-    MangaProviding,
-    ChapterProviding,
-    DiscoverSectionProviding,
-    SettingsFormProviding,
-    CloudflareBypassRequestProviding
-{
+export abstract class MadaraGeneric implements ExtensionImpl<typeof basePbConfig> {
   /**
    * The Madara URL of the website. Eg. https://webtoon.xyz
    */

--- a/src/generic/network.ts
+++ b/src/generic/network.ts
@@ -77,7 +77,10 @@ export class MadaraInterceptor extends PaperbackInterceptor {
     data: ArrayBuffer,
   ): Promise<ArrayBuffer> {
     const cfMitigated = response.headers?.["cf-mitigated"];
-    if (cfMitigated === "challenge") {
+    const isRecaptcha =
+      response.status === 403 && Application.arrayBufferToUTF8String(data).includes("recaptcha");
+
+    if (cfMitigated === "challenge" || isRecaptcha) {
       throw new CloudflareError(
         {
           url: this.source.bypassPage ? this.source.bypassPage : this.source.domain,
@@ -88,7 +91,7 @@ export class MadaraInterceptor extends PaperbackInterceptor {
             "user-agent": await Application.getDefaultUserAgent(),
           },
         },
-        "Cloudflare detected, bypass it to continue!",
+        "Bot verification detected, bypass it to continue!",
       );
     }
 


### PR DESCRIPTION
# Summary

- Fix LilyManga Search Selector
- Add ReCaptcha bypass

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
